### PR TITLE
Show tmpfs info earlier in the boot process

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('Readme.md', encoding='utf-8') as f:
 
 setup(
     name='verity-squash-root',
-    version='0.3.0',
+    version='0.3.1',
     description='Build a signed efi binary which mounts a '
                 'verified squashfs image as rootfs',
     long_description=readme,

--- a/usr/lib/dracut/modules.d/99verity-squash-root/cryptsetup_overlay.conf
+++ b/usr/lib/dracut/modules.d/99verity-squash-root/cryptsetup_overlay.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=verity-squash-root-notifiy.service
+Wants=verity-squash-root-notifiy.service

--- a/usr/lib/dracut/modules.d/99verity-squash-root/dracut_mount_overlay.conf
+++ b/usr/lib/dracut/modules.d/99verity-squash-root/dracut_mount_overlay.conf
@@ -1,6 +1,8 @@
 [Unit]
 # Reset ALL conditions
 ConditionDirectoryNotEmpty=
+After=verity-squash-root-notifiy.service
+Wants=verity-squash-root-notifiy.service
 
 [Service]
 StandardInput=tty

--- a/usr/lib/dracut/modules.d/99verity-squash-root/module-setup.sh
+++ b/usr/lib/dracut/modules.d/99verity-squash-root/module-setup.sh
@@ -54,13 +54,21 @@ install() {
 	mkdir -p "${initdir}"/overlayroot
 	mkdir -p "${initdir}"/verity-squash-root-tmp/squashroot
 	mkdir -p "${initdir}"/verity-squash-root-tmp/tmpfs
-	# mount handler
 	# shellcheck disable=SC2154
-	inst "${moddir}/verity_squash_root.conf" \
-		"${systemdsystemunitdir}/dracut-mount.service.d/"
+	local ssud="${systemdsystemunitdir}"
+	# shellcheck disable=SC2154
+	local mod="${moddir}"
+	inst "${mod}/dracut_mount_overlay.conf" \
+		"${ssud}/dracut-mount.service.d/verity-squash-root.conf"
+	inst "${mod}/cryptsetup_overlay.conf" \
+		"${ssud}/systemd-cryptsetup@.service.d/verity-squash-root.conf"
+	inst /usr/lib/systemd/system/verity-squash-root-notifiy.service
+
+	inst /usr/lib/verity-squash-root/functions
 	inst /usr/lib/verity-squash-root/mount_handler
 	inst /usr/lib/verity-squash-root/mount_handler_dracut
-	DRACUT_RESOLVE_DEPS=1 inst_multiple mount umount uname veritysetup
+	inst /usr/lib/verity-squash-root/show_boot_info
+	DRACUT_RESOLVE_DEPS=1 inst_multiple mount umount sed sleep veritysetup
 
 	# needed for veritysetup
 	inst_binary dmeventd

--- a/usr/lib/initcpio/install/verity-squash-root
+++ b/usr/lib/initcpio/install/verity-squash-root
@@ -10,13 +10,16 @@ date_or_override() {
 }
 
 build() {
+	add_binary sed
+	add_binary sleep
 	add_binary mount
-	add_binary uname
 	add_binary veritysetup
 	add_dir /overlayroot
 	add_dir /verity-squash-root-tmp/squashroot
 	add_dir /verity-squash-root-tmp/tmpfs
 	add_file "/usr/lib/verity-squash-root/mount_handler"
+	add_file "/usr/lib/verity-squash-root/functions"
+	add_file "/usr/lib/verity-squash-root/show_boot_info"
 	date_or_override > "${BUILDROOT}/VERITY_SQUASH_ROOT_DATE"
 
 	add_module dm_mod
@@ -26,20 +29,21 @@ build() {
 	add_module squashfs
 
 	if type add_systemd_unit &> /dev/null; then
-		cat <<EOF | add_systemd_drop_in initrd-switch-root.service squashroot
+		add_systemd_unit verity-squash-root-notifiy.service
+		cat <<EOF | add_systemd_drop_in initrd-switch-root.service verity-squash-root
 [Unit]
-Requires=systemd-vconsole-setup.service
-After=plymouth-start.service systemd-vconsole-setup.service
+After=verity-squash-root-notifiy.service
+Wants=verity-squash-root-notifiy.service
 
 [Service]
-# needed for read, when tmpfs is used
-StandardInput=tty
-StandardOutput=tty
-TimeoutStartSec=infinity
-
 ExecStart=
 ExecStart=sh /usr/lib/verity-squash-root/mount_handler /sysroot /overlayroot
 ExecStart=systemctl --no-block switch-root /overlayroot
+EOF
+		cat <<EOF | add_systemd_drop_in systemd-cryptsetup@.service verity-squash-root-notifiy
+[Unit]
+After=verity-squash-root-notifiy.service
+Wants=verity-squash-root-notifiy.service
 EOF
 	else
 		error "Only systemd variant is supported"

--- a/usr/lib/systemd/system/verity-squash-root-notifiy.service
+++ b/usr/lib/systemd/system/verity-squash-root-notifiy.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Show info in volatile mode for rollback prevention
+DefaultDependencies=no
+Conflicts=multi-user.target
+
+After=systemd-vconsole-setup.service
+Before=initrd-switch-root.service
+Requires=systemd-vconsole-setup.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=-sh /usr/lib/verity-squash-root/show_boot_info
+
+StandardInput=tty
+StandardOutput=tty
+StandardError=tty
+TimeoutStartSec=10min
+
+[Install]
+WantedBy=sysinit.target

--- a/usr/lib/verity-squash-root/functions
+++ b/usr/lib/verity-squash-root/functions
@@ -1,0 +1,14 @@
+#!/usr/bin/sh
+set -e
+export KP_NAME="verity_squash_root"
+__KERNEL_CMDLINE="$(sed -E -e 's/ |\t/\n/g' < /proc/cmdline)"
+get_kparam() {
+	sed -e '/^'"${1}"='/!d' -e 's/^'"${1}"'=//g' <<EOF
+${__KERNEL_CMDLINE}
+EOF
+}
+get_kparam_set() {
+	sed -e '/^'"${1}"'$/!d' <<EOF
+${__KERNEL_CMDLINE}
+EOF
+}

--- a/usr/lib/verity-squash-root/mount_handler
+++ b/usr/lib/verity-squash-root/mount_handler
@@ -1,17 +1,6 @@
 #!/usr/bin/sh
 set -e
-kernel_params="$(sed -e 's/ /\n/g' < /proc/cmdline)"
-get_kparam() {
-	sed -e '/^'"${1}"='/!d' -e 's/^'"${1}"'=//g' <<EOF
-${kernel_params}
-EOF
-}
-get_kparam_set() {
-	sed -e '/^'"${1}"'$/!d' <<EOF
-${kernel_params}
-EOF
-}
-KP_NAME="verity_squash_root"
+. /usr/lib/verity-squash-root/functions
 SLOT="$(get_kparam "${KP_NAME}_slot")"
 ROOTHASH="$(get_kparam "${KP_NAME}_hash")"
 VOLATILE="$(get_kparam_set "${KP_NAME}_volatile")"
@@ -21,11 +10,6 @@ TMP="/verity-squash-root-tmp"
 if [ "${VOLATILE}" = "${KP_NAME}_volatile" ]; then
 	OLROOT="${TMP}/tmpfs"
 	mount -t tmpfs tmpfs "${OLROOT}"
-	# Print date so rollback attacks can be detected
-	printf "You are booting a tmpfs overlay (slot %s) built at " "${SLOT}"
-	cat "/VERITY_SQUASH_ROOT_DATE"
-	printf "Press enter to continue\\n"
-	read -r _
 else
 	OLROOT="${ROOT}"
 fi

--- a/usr/lib/verity-squash-root/show_boot_info
+++ b/usr/lib/verity-squash-root/show_boot_info
@@ -1,0 +1,14 @@
+#!/usr/bin/sh
+. /usr/lib/verity-squash-root/functions
+set -e
+SLOT="$(get_kparam "${KP_NAME}_slot")"
+VOLATILE="$(get_kparam_set "${KP_NAME}_volatile")"
+if [ "${VOLATILE}" = "${KP_NAME}_volatile" ]; then
+	# Give systemd time to print messages, this results in a cleaner output
+	sleep 1 || true
+	# Print date so rollback attacks can be detected
+	printf "You are booting a tmpfs overlay (slot %s) built at " "${SLOT}"
+	cat "/VERITY_SQUASH_ROOT_DATE"
+	printf "Press enter to continue\\n"
+	read -r _
+fi


### PR DESCRIPTION
Without this change, an attacker can modify the rootfs to show the tmpfs screen (while booting a non tmpfs variant).

Other changes while refactoring:
- Use Wants= instead of Requires= where no hard dependency is needed to prevent potential boot failures (nothing known yet).
- Remove unneeded uname from initramfs
- Add missing sed to initramfs (no known issue yet)